### PR TITLE
[0402] Mythology of the Titans spawntime fix

### DIFF
--- a/updates/0402_gameobject.sql
+++ b/updates/0402_gameobject.sql
@@ -1,0 +1,2 @@
+-- Sets spawntime of Mythology of the Titans to 50 seconds. http://thottbot.com/quest=1050 "All you gotta do is wait there for at least 50 secs"
+UPDATE `gameobject` SET `spawntimesecs`='50' WHERE (`guid`='15008');


### PR DESCRIPTION
Sets spawntime of Mythology of the Titans to 50 seconds down from 5
minutes. http://thottbot.com/quest=1050 "All you gotta do is wait there
for at least 50 secs"
