### PR TITLE
Removing Bolts of Cloth from creature loot tables

### DIFF
--- a/updates/remove_cloth.sql
+++ b/updates/remove_cloth.sql
@@ -1,0 +1,13 @@
+--Removing Bolts of Cloth from Creature Loot Templates
+--Bolts of cloth weren't dropped by creatures
+
+--Bolt of Linen Cloth
+DELETE FROM `creature_loot_template` WHERE `item` = 2996;
+--Bolt of Woolen Cloth
+DELETE FROM `creature_loot_template` WHERE `item` = 2997;
+--Bolt of Silk Cloth
+DELETE FROM `creature_loot_template` WHERE `item` = 4305;
+--Bolt of Mageweave
+DELETE FROM `creature_loot_template` WHERE `item` = 4339;
+--Bolt of Runecloth
+DELETE FROM `creature_loot_template` WHERE `item` = 14048;


### PR DESCRIPTION
- Bolts of Cloth don't drop from creatures
