### PR TITLE
Updated NPC Flag on Rivern Frostwind

### DIFF
--- a/updates/frostsaber_provisions.sql
+++ b/updates/frostsaber_provisions.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template` SET `npcflag`='7' WHERE `entry`='10618';


### PR DESCRIPTION
Quests were not obtainable as NPC had wrong NPC flag

https://camo.githubusercontent.com/7260fa72cadec151b1af76950515988e150bd22f/68747470733a2f2f662e636c6f75642e6769746875622e636f6d2f6173736574732f343534303033362f313332303036362f37646462626330632d333333342d313165332d383564642d3566376337323035633334312e6a7067

With NPC Flag 7 he uses gossips, gives quests and sells his mount when Exalted.
