### PR TITLE
Molten Core - fixed movement of lucifron & his adds

### DIFF
--- a/updates/_creature.sql
+++ b/updates/_creature.sql
@@ -1,5 +1,6 @@
 -- correct spawnposition of lucifron & adds(ID 12118 & 12119)
--- SET @GUID := 80849;
+
+DELETE FROM `creature` where id = 12118 or id = 12119;
 
 INSERT INTO `creature` (`guid`,`id`,`map`,`modelid`,`equipment_id`,`position_x`,`position_y`,`position_z`,`orientation`,`spawntimesecs`,`spawndist`,`currentwaypoint`,`curhealth`,`curmana`,`DeathState`,`MovementType`) VALUES 
 (56605,12118,409,0,938,1068.86,-1007.76,-185.24,2.3,604800,5,0,351780,39300,0,2),

--- a/updates/_creature.sql
+++ b/updates/_creature.sql
@@ -1,0 +1,7 @@
+-- correct spawnposition of lucifron & adds(ID 12118 & 12119)
+-- SET @GUID := 80849;
+
+INSERT INTO `creature` (`guid`,`id`,`map`,`modelid`,`equipment_id`,`position_x`,`position_y`,`position_z`,`orientation`,`spawntimesecs`,`spawndist`,`currentwaypoint`,`curhealth`,`curmana`,`DeathState`,`MovementType`) VALUES 
+(56605,12118,409,0,938,1068.86,-1007.76,-185.24,2.3,604800,5,0,351780,39300,0,2),
+(56606,12119,409,12030,0,1067.9,-1011.6,-185.08,2.34,7200,5,0,90650,25680,0,0),
+(56607,12119,409,12030,0,1072.56,-1006.57,-185.91,2.4,7200,5,0,90650,25680,0,0);

--- a/updates/_creature_model_info.sql
+++ b/updates/_creature_model_info.sql
@@ -1,0 +1,3 @@
+-- correct boundingradius of lucifron & adds, else they follow way too far off
+
+UPDATE `creature_model_info` SET `bounding_radius` = 0 WHERE `modelid` = 12030 OR 13031

--- a/updates/_creature_movement.sql
+++ b/updates/_creature_movement.sql
@@ -1,0 +1,4 @@
+-- delete old waypoints of lucifron & adds
+
+DELETE FROM creature_movement WHERE id = 56605; -- lucifron
+DELETE FROM creature_movement WHERE id = 56606 OR id = 56607; -- adds

--- a/updates/_creature_movement_template.sql
+++ b/updates/_creature_movement_template.sql
@@ -1,7 +1,4 @@
--- Added correct Waypoints to Lucifron(ID 12188)
-
-DELETE FROM creature_movement WHERE id = 56605; -- lucifron
-DELETE FROM creature_movement WHERE id = 56606 OR id = 56607; -- adds
+-- add correct waypoints for lucifron
 
 INSERT INTO creature_movement_template (entry,point,position_x,position_y,position_z,orientation,wpguid,waittime) VALUES 
 

--- a/updates/_creature_movement_template.sql
+++ b/updates/_creature_movement_template.sql
@@ -1,0 +1,15 @@
+-- Added correct Waypoints to Lucifron(ID 12188)
+
+DELETE FROM creature_movement WHERE id = 56605; -- lucifron
+DELETE FROM creature_movement WHERE id = 56606 OR id = 56607; -- adds
+
+INSERT INTO creature_movement_template (entry,point,position_x,position_y,position_z,orientation,wpguid,waittime) VALUES 
+
+(12118,1,1068.86,-1007.76,-185.24,0,0,0),
+(12118,2,1041.65,-986.155,-181.509,0,0,0),
+(12118,3,1018.67,-979.646,-181.358,0,0,0),
+(12118,4,1010.5,-957.2,-180.027,0,0,0),
+(12118,5,1000.59,-954.883,-179.423,0,0,0),
+(12118,6,1010.5,-957.2,-180.027,0,0,0),
+(12118,7,1018.67,-979.646,-181.358,0,0,0),
+(12118,8,1041.65,-986.155,-181.509,0,0,0);


### PR DESCRIPTION
hey guys i'm new to this

the adds were following way too far behind lucifron, not where i spawned them!
i found out that if i set boundingradius of the models to 0 it works correctly, but i don't know if that is the correct way or if there are sideeffects
