### PR TITLE
update combat_reach and bounding_radius for dragon bosses & cthun

### DIFF
--- a/updates/_creature_model_info.sql
+++ b/updates/_creature_model_info.sql
@@ -1,0 +1,11 @@
+UPDATE creature_model_info SET bounding_radius = 17, combat_reach = 18 WHERE modelid = 8570; -- ony
+UPDATE creature_model_info SET bounding_radius = 16, combat_reach = 17 WHERE modelid = 11380; -- nefarian
+UPDATE creature_model_info SET bounding_radius = 15, combat_reach = 17 WHERE modelid = 11460; -- azuregos
+UPDATE creature_model_info SET bounding_radius = 12, combat_reach = 13 WHERE modelid = 13992; -- vael
+UPDATE creature_model_info SET bounding_radius = 0.63, combat_reach = 11 WHERE modelid = 15363; -- taerar
+UPDATE creature_model_info SET bounding_radius = 0.63, combat_reach = 18 WHERE modelid = 15364; -- ysondre
+UPDATE creature_model_info SET bounding_radius = 0.63, combat_reach = 18 WHERE modelid = 15365; -- lethon
+UPDATE creature_model_info SET bounding_radius = 1.8, combat_reach = 18 WHERE modelid = 15366; -- emeriss
+UPDATE creature_model_info SET bounding_radius = 0.0235, combat_reach = 14 WHERE modelid = 15556; -- eye of c'thun
+UPDATE creature_model_info SET bounding_radius = 14, combat_reach = 23 WHERE modelid = 15786; -- c'thun
+UPDATE creature_model_info SET bounding_radius = 0.77, combat_reach = 22 WHERE modelid = 16033; -- sapphiron


### PR DESCRIPTION
these big bosses have a really small combat_reach, so to melee them you have to stand inside them and they stand inside the tank to melee him. i just briefly checked all bosses, there are probably some more which need an update.
i found almost all correct values in trinitydb, but eye of cthun was 1 so i had a look at it myself on blizzard servers and guessed. i also included bounding_radius from trinitydb for movement.
