### PR TITLE
Removing Noblegarden items from creature loot

### DIFF
--- a/updates/0711_creature_loot_template.sql
+++ b/updates/0711_creature_loot_template.sql
@@ -1,0 +1,12 @@
+--Removing Noblegarden items from creature loot
+
+-- 6833 White Tuxedo Shirt
+-- 6834 Black Tuxedo Shirt
+-- 6835 Black Tuxedo Pants
+-- 7806 Lollipop
+-- 7807 Candy Bar
+-- 7808 Chocolate Square
+-- 7809 Easter Dress
+--19028 Elegant Dress
+
+DELETE FROM `creature_loot_template` WHERE `item` IN (6833, 6834, 6835, 7806, 7807, 7808, 7809, 19028);


### PR DESCRIPTION
-  6833 - White Tuxedo Shirt
-  6834 - Black Tuxedo
-  6835 - Black Tuxedo Pants
-  7806 - Lollipop
-  7807 - Candy Bar
-  7808 - Chocolate Square
-  7809 - Easter Dress
- 19028 - Elegant Dress

Thanks to @Patman64 for pointing, this solves #552 
