### PR TITLE
Fixed 'too many arguments' error in InstallFullDB.sh

### DIFF
--- a/InstallFullDB.sh
+++ b/InstallFullDB.sh
@@ -170,23 +170,16 @@ then
   done
 
   # Apply remaining files from main folder
-  for UPDATEFILE in ${CORE_PATH}/sql/updates/mangos/z*_*_mangos_*.sql
+  for f in $CORE_PATH/sql/updates/mangos/z*_*_mangos_*.sql
   do
-    if [ -e "$UPDATEFILE" ]
+    CUR_REV=`basename $f | sed 's/^\z\([0-9]*\)_.*/\1/' `
+    if [ "$CUR_REV" -gt "$LAST_CORE_REV" ]
     then
-      for f in ${CORE_PATH}/sql/updates/mangos/z*_*_mangos_*.sql
-      do
-        CUR_REV=`basename $f | sed 's/^\z\([0-9]*\)_.*/\1/' `
-        if [ "$CUR_REV" -gt "$LAST_CORE_REV" ]
-        then
-          # found a newer core update file
-          echo "Append core update `basename $f` to database DATABASE"
-        fi
-      done
-    else
-      echo "No core updates found at path ${CORE_PATH}/sql/updates/mangos"
+      # found a newer core update file
+      echo "Append core update `basename $f` to database $DATABASE"
+      $MYSQL_COMMAND < $f
+      [[ $? != 0 ]] && exit 1
     fi
-    break
   done
   echo "All core updates applied"
 fi

--- a/InstallFullDB.sh
+++ b/InstallFullDB.sh
@@ -113,18 +113,22 @@ $MYSQL_COMMAND < ${ADDITIONAL_PATH}Full_DB/ClassicDB_1_6_5_z2683.sql
 
 ## Updates
 echo "Process database updates"
-if [ ! -e ${ADDITIONAL_PATH}updates/[0-9]*.sql ]
-then
-    echo "   No update to process"
-else
-    for UPDATE in ${ADDITIONAL_PATH}updates/[0-9]*.sql
-    do
-        echo "   process update $UPDATE"
-        $MYSQL_COMMAND < $UPDATE
-        [[ $? != 0 ]] && exit 1
-    done
-    echo "Updates applied"
-fi
+for UPDATEFILE in ${ADDITIONAL_PATH}updates/[0-9]*.sql
+do
+    if [ -e "$UPDATEFILE" ]
+    then
+        for UPDATE in ${ADDITIONAL_PATH}updates/[0-9]*.sql
+        do
+            echo "   process update $UPDATE"
+            $MYSQL_COMMAND < $UPDATE
+            [[ $? != 0 ]] && exit 1
+        done
+        echo "Updates applied"
+    else
+        echo "   No update to process"
+    fi
+    break
+done
 
 LAST_CORE_REV="2683"
 # process future release folders

--- a/InstallFullDB.sh
+++ b/InstallFullDB.sh
@@ -170,16 +170,23 @@ then
   done
 
   # Apply remaining files from main folder
-  for f in $CORE_PATH/sql/updates/mangos/z*_*_mangos_*.sql
+  for UPDATEFILE in ${CORE_PATH}/sql/updates/mangos/z*_*_mangos_*.sql
   do
-    CUR_REV=`basename $f | sed 's/^\z\([0-9]*\)_.*/\1/' `
-    if [ "$CUR_REV" -gt "$LAST_CORE_REV" ]
+    if [ -e "$UPDATEFILE" ]
     then
-      # found a newer core update file
-      echo "Append core update `basename $f` to database $DATABASE"
-      $MYSQL_COMMAND < $f
-      [[ $? != 0 ]] && exit 1
+      for f in ${CORE_PATH}/sql/updates/mangos/z*_*_mangos_*.sql
+      do
+        CUR_REV=`basename $f | sed 's/^\z\([0-9]*\)_.*/\1/' `
+        if [ "$CUR_REV" -gt "$LAST_CORE_REV" ]
+        then
+          # found a newer core update file
+          echo "Append core update `basename $f` to database DATABASE"
+        fi
+      done
+    else
+      echo "No core updates found at path ${CORE_PATH}/sql/updates/mangos"
     fi
+    break
   done
   echo "All core updates applied"
 fi


### PR DESCRIPTION
Topic: https://github.com/classicdb/database/issues/831

The script used the updates correctly, but left an annoying error message:
./InstallFullDB.sh: line 116: [: too many arguments

The file existence test (-e) cannot accept the multiple argument returned by the regular expression.
To work around this, I used a solution which was considered the safest and most efficient here:
http://stackoverflow.com/questions/6363441/check-if-a-file-exists-with-wildcard-in-shell-script
The outer for loop will break on the first cycle.

I tested this only on Debian, so some test with Windows & GitBash are welcome.
