### PR TITLE
Corrected the droprate of Witchwing Talon

### DIFF
--- a/updates/13xx_witchwing_talon.sql
+++ b/updates/13xx_witchwing_talon.sql
@@ -1,0 +1,2 @@
+
+UPDATE `creature_loot_template` SET `ChanceOrQuestChance`='-80' WHERE `item`='5064';


### PR DESCRIPTION
Source: http://db.vanillagaming.org/?item=5064
Previously it was 39% for every related harpy.
