### PR TITLE
Defias Messenger

### DIFF
--- a/updates/9999_defias_messenger.sql
+++ b/updates/9999_defias_messenger.sql
@@ -1,0 +1,2 @@
+-- Fix Defias Messenger being a dishonourable kill
+UPDATE creature_template SET Civilian= 0 WHERE Entry= 550;


### PR DESCRIPTION
Fixes killing the Defias messenger being counted as a dishonourable kill.
I wondered where that DK had come from and when I saw something about him being marked as a civilian it was obvious.
