### PR TITLE
Practice lockbox fixes

### DIFF
--- a/updates/13xx_practice_lockbox.sql
+++ b/updates/13xx_practice_lockbox.sql
@@ -1,0 +1,3 @@
+
+UPDATE `gameobject_template` SET `data2`='0' WHERE `entry`='123330' OR `entry`='123331' OR `entry`='123332' OR `entry`='123333';
+UPDATE `gameobject` SET `spawntimesecs`='5' WHERE `id`='123330' OR `id`='123331' OR `id`='123332' OR `id`='123333' OR `id`='178246';


### PR DESCRIPTION
As a rouge of the horde, you are expected to level lockpicking with the _Buccaneer's Strongboxes_ (entry 123330) in the 'lockpicking quest'. These do not work as expected, because they won't despawn after being picked. This means once you open them, they won't grant any more skill increases.

On the alliance side, the rouges pick _Practice Lockboxes_ (entry 178244 and 178246), which do despawn correctly after being picked. It seems this was related to the data2 flag, because setting that for the _Buccaneer's Strongboxes_ made them despawn as expected.

The respawn time of all the boxes were all over the place. The _Buccaneer's Strongboxes_ had a respawn time of 2 seconds, which is way too fast in my opinion. I remember running around on retail for the boxes. On the alliance side three of the boxes had 5 seconds (which is fair), and two of the boxes had 7200 seconds (which is strange). So I set the respawn time of all the boxes to 5 seconds.
