### PR TITLE
Instance spawn positions

### DIFF
--- a/updates/14xx_areatrigger_position.sql
+++ b/updates/14xx_areatrigger_position.sql
@@ -1,0 +1,191 @@
+-- AREATRIGGER
+
+-- Ragefire Chasm
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Ragefire Chasm - Entering', `target_position_x`=0.797643, `target_position_y`=-8.23429, `target_position_z`=-15.5288, `target_orientation`=4.71239 WHERE `id`=2230;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Ragefire Chasm - Exiting', `target_position_x`=1814.99, `target_position_y`=-4419.23, `target_position_z`=-18.8151, `target_orientation`=1.91986 WHERE `id`=2226;
+
+-- Deadmines
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Deadmines - Entering', `target_position_x`=-14.5732, `target_position_y`=-385.475, `target_position_z`=62.4561, `target_orientation`=1.5708 WHERE `id`=78;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Deadmines - Exiting', `target_position_x`=-11208.7, `target_position_y`=1675.9, `target_position_z`=24.5733, `target_orientation`=4.71239 WHERE `id`=119;
+-- Exiting after ship
+UPDATE `areatrigger_teleport` SET `name`='Deadmines - Exiting after ship', `target_position_x`=-11339.9, `target_position_y`=1572.45, `target_position_z`=94.3916, `target_orientation`=1.5708 WHERE `id`=121;
+
+-- Shadowfang Keep
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Shadowfang Keep - Entering', `target_position_x`=-228.191, `target_position_y`=2111.41, `target_position_z`=76.8904, `target_orientation`=1.22173 WHERE `id`=145;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Shadowfang Keep - Exiting', `target_position_x`=-233.011, `target_position_y`=1567.5, `target_position_z`=76.8921, `target_orientation`=4.27606 WHERE `id`=194;
+
+-- BlackFATHOM Deeps (wrongfully named Blackphantom in our table names)
+-- Entering 	
+UPDATE `areatrigger_teleport` SET `name`='Blackfathom Deeps - Entering', `target_position_x`=-150.234, `target_position_y`=106.594, `target_position_z`=-39.779, `target_orientation`=4.45059 WHERE `id`=257;
+
+-- Stormwind Stockades
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Stormwind Stockades - Entering', `target_position_x`=48.9849, `target_position_y`=0.483882, `target_position_z`=-16.3942, `target_orientation`=0 WHERE `id`=101;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Stormwind stockades - Exiting', `target_position_x`=-8766.11, `target_position_y`=845.499, `target_position_z`=87.9952, `target_orientation`=3.83972 WHERE `id`=503;
+
+-- Gnomeregan
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Gnomeregan - Entering', `target_position_x`=-329.098, `target_position_y`=-3.20722, `target_position_z`=-152.851, `target_orientation`=2.96706 WHERE `id`=324;
+
+-- Razorfen Kraul
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Razorfen Kraul - Entering', `target_position_x`=1942.27, `target_position_y`=1544.23, `target_position_z`=83.3055, `target_orientation`=1.309 WHERE `id`=244;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Razorfen Kraul - Exiting', `target_position_x`=-4463.32, `target_position_y`=-1664.29, `target_position_z`=84.0489, `target_orientation`=3.92699 WHERE `id`=242;
+
+-- Scarlet Monestary - Graveyard
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Scarlet Monestary Graveyard - Entering', `target_position_x`=1687.27, `target_position_y`=1050.09, `target_position_z`=18.6773, `target_orientation`=1.5708 WHERE `id`=45;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Scarlet Monestary Graveyard - Exiting', `target_position_x`=2915.34, `target_position_y`=-801.58, `target_position_z`=160.333, `target_orientation`=3.49066 WHERE `id`=602;
+
+-- Scarlet Monestary - Library
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Scarlet Monestary Library - Entering', `target_position_x`=253.672, `target_position_y`=-206.624, `target_position_z`=18.6773, `target_orientation`=4.71239 WHERE `id`=614;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Scarlet Monestary Library - Exiting', `target_position_x`=2869.32, `target_position_y`=-820.818, `target_position_z`=160.333, `target_orientation`=0.349066 WHERE `id`=608;
+
+-- Scarlet Monestary - Armory
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Scarlet Monestary Armory - Entering', `target_position_x`=1608.1, `target_position_y`=-318.919, `target_position_z`=18.6714, `target_orientation`=4.71239 WHERE `id`=612;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Scarlet Monestary Armory - Exiting', `target_position_x`=2885.96, `target_position_y`=-835.802, `target_position_z`=160.327, `target_orientation`=0.349066 WHERE `id`=606;
+
+-- Scarlet Monestary - Cathedral
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Scarlet Monestary Cathedral - Entering', `target_position_x`=853.179, `target_position_y`=1319.18, `target_position_z`=18.6714, `target_orientation`=1.5708 WHERE `id`=610;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Scarlet Monestary Cathedral - Exiting', `target_position_x`=2915.13, `target_position_y`=-823.637, `target_position_z`=160.327, `target_orientation`=3.49066 WHERE `id`=604;
+
+-- Uldaman
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Uldaman - Entering', `target_position_x`=-228.859, `target_position_y`=46.1018, `target_position_z`=-46.0186, `target_orientation`=1.5708 WHERE `id`=286;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Uldaman - Exiting', `target_position_x`=-6066.25, `target_position_y`=-2954.56, `target_position_z`=209.772, `target_orientation`=3.14159 WHERE `id`=288;
+
+-- Zul'Farrak
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Zul\'Farrak - Entering', `target_position_x`=1212.67, `target_position_y`=842.04, `target_position_z`=8.93346, `target_orientation`=0 WHERE `id`=924;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Zul\'Farrak - Exiting', `target_position_x`=-6795.56, `target_position_y`=-2890.72, `target_position_z`=8.88742, `target_orientation`=3.14159 WHERE `id`=922;
+
+-- Maraudon - Orange
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Maraudon Orange - Entering', `target_position_x`=1016.83, `target_position_y`=-458.52, `target_position_z`=-43.4737, `target_orientation`=0 WHERE `id`=3133;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Maraudon Orange - Exiting', `target_position_x`=-1468.2, `target_position_y`=2614.21, `target_position_z`=76.3804, `target_orientation`=0 WHERE `id`=3131;
+
+-- Maraudon - Purple
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Maraudon Purple - Entering', `target_position_x`=755.078, `target_position_y`=-617.696, `target_position_z`=-32.9222, `target_orientation`=1.5708 WHERE `id`=3134;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Maraudon Purple - Exiting', `target_position_x`=-1182.8, `target_position_y`=2877.43, `target_position_z`=85.908, `target_orientation`=1.65806 WHERE `id`=3126;
+
+-- Sunken Temple
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Altar of Atal\'Hakkar (Sunken Temple) - Entering', `target_position_x`=-315.903, `target_position_y`=100.197, `target_position_z`=-131.849, `target_orientation`=3.14159 WHERE `id`=446;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Altar of Atal\'Hakkar (Sunken Temple) - Exiting', `target_position_x`=-10176.6, `target_position_y`=-3995.35, `target_position_z`=-112.185, `target_orientation`=3.00197 WHERE `id`=448;
+
+-- Blackrock Depths
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Blackrock Depths - Entering', `target_position_x`=456.929, `target_position_y`=34.0923, `target_position_z`=-68.0896, `target_orientation`=4.71239 WHERE `id`=1466;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Blackrock Depths - Exiting', `target_position_x`=-7178.41, `target_position_y`=-922.152, `target_position_z`=166.092, `target_orientation`=2.00713 WHERE `id`=1472;
+
+-- Blackrock Spire
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Blackrock Spire - Entering', `target_position_x`=78.3534, `target_position_y`=-226.841, `target_position_z`=49.7662, `target_orientation`=4.71239 WHERE `id`=1468;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Blackrock Spire - Exiting', `target_position_x`=-7524.7, `target_position_y`=-1228.41, `target_position_z`=287.204, `target_orientation`=1.74533 WHERE `id`=1470;
+
+-- Dire Maul - East
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Dire Maul East - Entering', `target_position_x`=47.4501, `target_position_y`=-153.665, `target_position_z`=-2.71439, `target_orientation`=5.49779 WHERE `id`=3183;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Dire Maul East - Exiting', `target_position_x`=-3738.62, `target_position_y`=934.522, `target_position_z`=160.975, `target_orientation`=3.14159 WHERE `id`=3194;
+-- Exiting after Alzzin
+UPDATE `areatrigger_teleport` SET `name`='Dire Maul East - Exiting after Alzzin', `target_position_x`=-3585.84, `target_position_y`=847.367, `target_position_z`=138.641, `target_orientation`=2.35619 WHERE `id`=3197;
+
+-- Dire Maul - East (Back Door)
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Dire Maul East - Entering Back Door', `target_position_x`=10.5786, `target_position_y`=-836.991, `target_position_z`=-32.3988, `target_orientation`=0 WHERE `id`=3185;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Dire Maul East - Exiting Back Door', `target_position_x`=-4031.25, `target_position_y`=129.345, `target_position_z`=26.4744, `target_orientation`=2.70526 WHERE `id`=3196;
+
+-- Dire Maul - West
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Dire Maul West - Entering', `target_position_x`=-65.6559, `target_position_y`=159.561, `target_position_z`=-3.4647, `target_orientation`=2.35619 WHERE `id`=3186;
+
+-- Dire Maul - West (Side Door)
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Dire Maul West - Entering Side Door', `target_position_x`=33.1083, `target_position_y`=158.977, `target_position_z`=-3.47126, `target_orientation`=0.785398 WHERE `id`=3187;
+
+-- Dire Maul - North
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Dire Maul North - Entering', `target_position_x`=254.92, `target_position_y`=-19.463, `target_position_z`=-2.5596, `target_orientation`=5.49779 WHERE `id`=3189;
+
+-- Stratholme - Front
+-- Entering (Left)
+UPDATE `areatrigger_teleport` SET `name`='Stratholme - Entering Left Front', `target_position_x`=3392.92, `target_position_y`=-3395.03, `target_position_z`=143.135, `target_orientation`=1.5708 WHERE `id`=2216;
+-- Entering (Right)
+UPDATE `areatrigger_teleport` SET `name`='Stratholme - Entering Right Front', `target_position_x`=3392.84, `target_position_y`=-3364.44, `target_position_z`=142.965, `target_orientation`=4.71239 WHERE `id`=2217;
+
+-- Stratholme - UD
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Stratholme - Entering Back Door', `target_position_x`=3590.87, `target_position_y`=-3643.22, `target_position_z`=138.491, `target_orientation`=5.49779 WHERE `id`=2214;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Stratholme - Exiting Back Door', `target_position_x`=3233.06, `target_position_y`=-4048.3, `target_position_z`=108.442, `target_orientation`=2.00713 WHERE `id`=2221;
+
+-- Scholomance
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Scholomance - Entering', `target_position_x`=190.819, `target_position_y`=126.329, `target_position_z`=137.227, `target_orientation`=0 WHERE `id`=2567;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Scholomance - Exiting', `target_position_x`=1273.91, `target_position_y`=-2553.09, `target_position_z`=91.8393, `target_orientation`=3.57793 WHERE `id`=2568;
+
+-- Onyxia's Lair
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Onyxia\'s Lair - Entering', `target_position_x`=30.8916, `target_position_y`=-54.079, `target_position_z`=-5.02784, `target_orientation`=4.71239 WHERE `id`=2848;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Onyxia\'s Lair - Exiting', `target_position_x`=-4750.38, `target_position_y`=-3754.44, `target_position_z`=49.0485, `target_orientation`=0.785398 WHERE `id`=1064;
+
+-- Zul'Gurub
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Zul\'Gurub - Entering', `target_position_x`=-11916.6, `target_position_y`=-1243.52, `target_position_z`=92.5338, `target_orientation`=4.71239 WHERE `id`=3928;
+
+-- Blackwing Lair
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Blackwing Lair - Entering', `target_position_x`=-7672.32, `target_position_y`=-1107.05, `target_position_z`=396.651, `target_orientation`=0.785398 WHERE `id`=3726;
+
+-- Ruins of Ahn'Qiraj
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Ruins of Ahn\'Qiraj - Entering', `target_position_x`=-8436.53, `target_position_y`=1519.17, `target_position_z`=31.907, `target_orientation`=2.61799 WHERE `id`=4008;
+
+-- Ahn'Qiraj Temple
+-- Entering
+UPDATE `areatrigger_teleport` SET `name`='Ahn\'Qiraj Temple - Entering', `target_position_x`=-8221.35, `target_position_y`=2014.34, `target_position_z`=129.071, `target_orientation`=0.872665 WHERE `id`=4010;
+-- Exiting
+UPDATE `areatrigger_teleport` SET `name`='Ahn\'Qiraj Temple - Exiting', `target_position_x`=-8239.01, `target_position_y`=1993.25, `target_position_z`=129.071, `target_orientation`=4.01426 WHERE `id`=4012;
+
+
+-- TARGET POSITION
+
+-- Blackfathom Deeps
+-- Exiting using Darnassus Portal
+UPDATE `spell_target_position` SET `target_position_x`=9664.14, `target_position_y`=2526.36, `target_position_z`=1334.27, `target_orientation`=1.84454 WHERE `id`=3565;
+
+-- Maraudon
+-- Portal to Earth Song Falls (Princess run)
+UPDATE `spell_target_position` SET `target_position_x`=386.27, `target_position_y`=33.4144, `target_position_z`=-130.934, `target_orientation`=0 WHERE `id`=21128;
+
+-- Molten Core
+-- Entering using High Elf (Attunement)
+UPDATE `spell_target_position` SET `target_position_x`=1080, `target_position_y`=-483, `target_position_z`=-108, `target_orientation`=1 WHERE `id`=20534;
+UPDATE `spell_target_position` SET `target_position_x`=1080, `target_position_y`=-483, `target_position_z`=-108, `target_orientation`=1 WHERE `id`=20618;


### PR DESCRIPTION
https://github.com/classicdb/database/issues/856

To be improved:

Have wrong height:
- Razorfen Kraul - both enter and exit
- Entering Blackrock Depths spawns in the air, leaving seems good.
- leaving Blackrock Spire.
- Leaving scholomance

Have wrong orientation:
- The orientation leaving Dire Maul East is clearly off

May have wrong orentation:
- Shadowfang keep - both entering and exiting
- Dire Maul West - Entering
- Dire Maul North - Entering
- The orientation leaving AQ20 seems very off.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/classicdb/database/888)

<!-- Reviewable:end -->
